### PR TITLE
re#18 fix marked.js to work when require js is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v1.3.2
+* issue #18: Fix markdown preview to work with crowdfusion v3.2.13 and higher.
+
 
 ## v1.3.1
 * Open sourced, removed private satis reference to wb-crowdfusion since that is also open source.

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
     <description>Provides various aspects, classes and templates for common functionality used on WB sites.
     </description>
     <priority>100</priority>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
   </info>
 
   <config>

--- a/view/cms/assets/js/md-editor/marked.js
+++ b/view/cms/assets/js/md-editor/marked.js
@@ -1276,6 +1276,7 @@ if (typeof module !== 'undefined' && typeof exports === 'object') {
   module.exports = marked;
 } else if (typeof define === 'function' && define.amd) {
   define(function() { return marked; });
+  this.marked = marked;
 } else {
   this.marked = marked;
 }


### PR DESCRIPTION
force marked.js to behave the same way if require js was defined or not